### PR TITLE
fix: IoT Button V2 button click not responding

### DIFF
--- a/components/light_sleep/light_sleep.cpp
+++ b/components/light_sleep/light_sleep.cpp
@@ -15,7 +15,7 @@ namespace esphome
 
         void LightSleep::setup()
         {
-            int gpio_num = wakeup_pin_;
+            const auto gpio_num = gpio_num_t(this->wakeup_pin_->get_pin());
 
             gpio_config_t config = {
                 .pin_bit_mask = 1ULL << gpio_num,
@@ -48,7 +48,7 @@ namespace esphome
 
         void LightSleep::enter_sleep()
         {
-            int gpio_num = wakeup_pin_;
+            const auto gpio_num = gpio_num_t(this->wakeup_pin_->get_pin());
 
             // Wait for the pin to be released (from low to high)
             if (gpio_get_level((gpio_num_t)gpio_num) == 0)

--- a/components/light_sleep/light_sleep.h
+++ b/components/light_sleep/light_sleep.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/gpio.h"
 #include <vector>
 
 namespace esphome
@@ -15,13 +16,13 @@ namespace esphome
       void dump_config() override;
       float get_setup_priority() const override { return setup_priority::DATA; }
 
-      void set_wakeup_pin(int pin) { wakeup_pin_ = pin; }
+      void set_wakeup_pin(InternalGPIOPin *pin) { this->wakeup_pin_ = pin; }
       void enter_sleep();
       void add_on_wakeup(Trigger<> *trigger) { this->wakeup_triggers_.push_back(trigger); }
       void add_on_prepare_sleep(Trigger<> *trigger) { this->prepare_sleep_triggers_.push_back(trigger); }
 
     protected:
-      int wakeup_pin_;
+      InternalGPIOPin *wakeup_pin_;
       std::vector<Trigger<> *> wakeup_triggers_;
       std::vector<Trigger<> *> prepare_sleep_triggers_;
     };

--- a/projects/seeedstudio-iot-button/seeedstudio-iot-button-v2.yaml
+++ b/projects/seeedstudio-iot-button/seeedstudio-iot-button-v2.yaml
@@ -106,7 +106,9 @@ output:
 
 light_sleep:
   id: light_sleep_1
-  wakeup_pin: 2
+  wakeup_pin:
+    number: GPIO2
+    allow_other_uses: True  # Also used as binary_sensor
   on_prepare_sleep:
     then:
       - logger.log: "Preparing to enter light sleep"
@@ -323,6 +325,7 @@ binary_sensor:
       mode:
         input: True
         pullup: True
+      allow_other_uses: True  # Also used as the wakeup pin for light_sleep
     name: "SeeedStudio IoT Button"
     on_multi_click:
       - timing:


### PR DESCRIPTION
@ciriousjoker diagnosed in https://github.com/Seeed-Studio/xiao-esphome-projects/issues/25#issuecomment-3634744506 that the pin needs to be annotated with `allow_other_uses` when it is used in multiple places, as documented in https://next.esphome.io/changelog/2023.12.0/#pin-reuse-validation.

Declaring the schema as `pins.gpio_input_pin_schema` allows this to be caught at compile time