### PR TITLE
Add device class for battery measurement sensor

### DIFF
--- a/projects/xiao-soil-moisture-monitor/xiao-soil-moisture-monitor.yaml
+++ b/projects/xiao-soil-moisture-monitor/xiao-soil-moisture-monitor.yaml
@@ -319,6 +319,7 @@ sensor:
   - platform: adc
     pin: GPIO0
     name: "Battery measurement"
+    device_class: "battery"
     attenuation: 12db
     # internal: true
     filters:                     # When the battery drops below 1V, it is dead.

--- a/projects/xiao-soil-moisture-monitor/xiao-soil-moisture-monitor.yaml
+++ b/projects/xiao-soil-moisture-monitor/xiao-soil-moisture-monitor.yaml
@@ -336,7 +336,7 @@ sensor:
     force_update: True
 
   - platform: wifi_signal
-    name: "wifi singnal strength"
+    name: "wifi signal strength"
     update_interval: 10s
     
 # text_sensor:


### PR DESCRIPTION
This will make the devices batter level show up on the home assistance's maintenance dashboard. 